### PR TITLE
feat: let the provider complete method also return the fetched profile

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -296,12 +296,12 @@ export default class Auth {
 		});
 
 		// Now, get the user profile.
-		await this.fetchProfile({ idToken, refreshToken, expiresAt });
+		const profile = await this.fetchProfile({ idToken, refreshToken, expiresAt });
 
 		// Remove sensitive data from the URLSearch params in the location bar.
 		history.replaceState(null, null, location.origin + location.pathname);
 
-		return context;
+		return { context, profile };
 	}
 
 	/**


### PR DESCRIPTION
In my use case I need to be able to retrieve the fetched profile after a the login with a provider completes.
Currently it only returns the context which doesn't have much.